### PR TITLE
brand-model parsing

### DIFF
--- a/lib/device.js
+++ b/lib/device.js
@@ -1,13 +1,19 @@
+var replaceMatches = require('./replaceMatches');
+
 exports.makeDefault = function makeDefault(str) {
     return {
         userAgent: str,
-        family: "Other"
+        family: "Other",
+        brand: null,
+        model: null
     };
 };
 
 exports.makeParser = function makeParser(obj) {
-  var regexp = new RegExp(obj.regex),
-      deviceRep = obj.device_replacement;
+  var regexp = new RegExp(obj.regex, obj.regex_flag || ''),
+      deviceRep = obj.device_replacement,
+      brandRep  = obj.brand_replacement,
+      modelRep  = obj.model_replacement;
 
   function parser(str) {
     var m = str.match(regexp);
@@ -15,7 +21,9 @@ exports.makeParser = function makeParser(obj) {
     
     return {
         userAgent: str,
-        family: deviceRep ? deviceRep.replace('$1', m[1]) : m[1]
+        family: deviceRep ? replaceMatches(deviceRep, m) : m[1],
+        brand:  brandRep  ? replaceMatches(brandRep, m)  : null,
+        model:  modelRep  ? replaceMatches(modelRep, m)  : m[1]            
     };
   }
 

--- a/lib/makeParser.js
+++ b/lib/makeParser.js
@@ -1,5 +1,5 @@
 module.exports = function makeParser(regexes, parserMaker, defaultObjMaker) {
-  var parsers = regexes.map(parserMaker)
+  var parsers = regexes.map(parserMaker);
 
   function parser(str) {
       var obj;
@@ -15,4 +15,4 @@ module.exports = function makeParser(regexes, parserMaker, defaultObjMaker) {
   }
 
   return parser;
-}
+};

--- a/lib/os.js
+++ b/lib/os.js
@@ -7,7 +7,7 @@ exports.makeDefault = function makeDefault(str) {
         patch: null,
         patchMinor: null
     };
-}
+};
 
 exports.makeParser = function makeParser(obj) {
   var regexp = new RegExp(obj.regex),
@@ -32,4 +32,4 @@ exports.makeParser = function makeParser(obj) {
   }
 
   return parser;
-}
+};

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -22,4 +22,4 @@ module.exports = function(regexes) {
 		parseOS: parseOS,
 		parseDevice: parseDevice
 	};
-}
+};

--- a/lib/replaceMatches.js
+++ b/lib/replaceMatches.js
@@ -1,0 +1,5 @@
+module.exports = function replaceMatches(str, m) {
+  return str.replace(/\$(\d)/g, function(tmp, i) {
+    return m[i] || '';
+  }).trim();
+};

--- a/lib/results.js
+++ b/lib/results.js
@@ -3,7 +3,7 @@ function Results(ua_str, ua, os, device) {
   this.userAgent = ua_str;
   this.ua = ua;
   this.os = os;
-  this.device = device
+  this.device = device;
   delete ua.userAgent;
   delete os.userAgent;
   delete device.userAgent;

--- a/lib/ua.js
+++ b/lib/ua.js
@@ -6,7 +6,7 @@ exports.makeDefault = function makeDefault(str) {
         minor: null,
         patch: null
     };
-}
+};
 
 exports.makeParser = function makeParser(obj) {
   var regexp = new RegExp(obj.regex),
@@ -29,4 +29,4 @@ exports.makeParser = function makeParser(obj) {
   }
 
   return parser;
-}
+};


### PR DESCRIPTION
For device parsing a better segmentation is being introduced for Android and other Devices.

To add information on "brand" and "model" two new types brand_replacement and model_replacement have been added to the device_parser in the regexes.yaml file. 

To facilitate segmentation a multi replacement function for "family", "brand" and "model" is introduced to cope with user-agent-strings which are quite different from each other but specify the same device. 
Now $1 ... $9 can be used to reference up to nine matchers.

For correct matching of Generic Feature-/ Smartphones and Spiders case insensitive matching using `regex_flag: 'i'` has been added. 
