### PR TITLE
device parser fix - respond with default values

### DIFF
--- a/lib/device.js
+++ b/lib/device.js
@@ -21,9 +21,9 @@ exports.makeParser = function makeParser(obj) {
     
     return {
         userAgent: str,
-        family: deviceRep ? replaceMatches(deviceRep, m) : m[1],
-        brand:  brandRep  ? replaceMatches(brandRep, m)  : null,
-        model:  modelRep  ? replaceMatches(modelRep, m)  : m[1]            
+        family: (deviceRep ? replaceMatches(deviceRep, m) : m[1]) || 'Other',
+        brand:  (brandRep  ? replaceMatches(brandRep, m)  : null) || null,
+        model:  (modelRep  ? replaceMatches(modelRep, m)  : m[1]) || null            
     };
   }
 


### PR DESCRIPTION
Removing the Device prototype causes different default values for brand-model matching.
This fix is a prerequisite to successfully pass brand-model tests.
